### PR TITLE
use `Satoshifier` instead of `Bip21Parser`directly to make sure lwk is initialized

### DIFF
--- a/example/integration_test/bip21_test.dart
+++ b/example/integration_test/bip21_test.dart
@@ -59,7 +59,7 @@ void main() {
   group('Bip21', () {
     for (final uri in valids) {
       test('parses $uri', () async {
-        final result = await Bip21Parser.parse(uri);
+        final result = await Satoshifier.parse(uri);
         expect(result, isA<Bip21>());
       });
     }


### PR DESCRIPTION
This PR fixes the integration tests that were unexpectedly failing for Liquid BIP21 parsing because of lwk not being initialized.